### PR TITLE
Creado endpoint GET /positions/:id/candidates

### DIFF
--- a/backend/api-spec.yaml
+++ b/backend/api-spec.yaml
@@ -185,4 +185,38 @@ paths:
           description: Invalid file type, only PDF and DOCX are allowed
         '500':
           description: Error during the file upload process
+  /positions/{id}/candidates:
+    get:
+      summary: Get candidates for a position
+      description: Retrieves all candidates in process for a given position.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: The ID of the position
+      responses:
+        '200':
+          description: A list of candidates
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    fullName:
+                      type: string
+                      description: Full name of the candidate
+                    currentInterviewStep:
+                      type: integer
+                      description: Current interview step of the candidate
+                    averageScore:
+                      type: number
+                      description: Average score of the candidate
+        '400':
+          description: Invalid position ID format
+        '500':
+          description: Internal server error
 

--- a/backend/api-spec.yaml
+++ b/backend/api-spec.yaml
@@ -219,4 +219,44 @@ paths:
           description: Invalid position ID format
         '500':
           description: Internal server error
+  /candidates/{candidateId}/applications/{applicationId}/stage:
+    put:
+      summary: Update candidate's interview stage
+      description: Updates the current interview stage of a specific candidate's application.
+      parameters:
+        - in: path
+          name: candidateId
+          required: true
+          schema:
+            type: integer
+          description: The ID of the candidate
+        - in: path
+          name: applicationId
+          required: true
+          schema:
+            type: integer
+          description: The ID of the application
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                stage:
+                  type: integer
+                  description: The new interview stage for the candidate's application
+      responses:
+        '200':
+          description: Application stage updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Application'
+        '400':
+          description: Invalid ID or stage format
+        '404':
+          description: Application not found
+        '500':
+          description: Internal server error
 

--- a/backend/src/application/services/candidateService.ts
+++ b/backend/src/application/services/candidateService.ts
@@ -3,6 +3,9 @@ import { validateCandidateData } from '../validator';
 import { Education } from '../../domain/models/Education';
 import { WorkExperience } from '../../domain/models/WorkExperience';
 import { Resume } from '../../domain/models/Resume';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
 
 export const addCandidate = async (candidateData: any) => {
     try {
@@ -61,5 +64,36 @@ export const findCandidateById = async (id: number): Promise<Candidate | null> =
     } catch (error) {
         console.error('Error al buscar el candidato:', error);
         throw new Error('Error al recuperar el candidato');
+    }
+};
+
+export const updateCandidateStage = async (candidateId: number, applicationId: number, stage: number) => {
+    try {
+        const updatedApplication = await prisma.application.updateMany({
+            where: {
+                id: applicationId,
+                candidateId: candidateId
+            },
+            data: {
+                currentInterviewStep: stage
+            }
+        });
+
+        if (updatedApplication.count === 0) {
+            return null;
+        }
+
+        return await prisma.application.findUnique({
+            where: {
+                id: applicationId
+            },
+            include: {
+                candidate: true,
+                position: true
+            }
+        });
+    } catch (error) {
+        console.error('Error updating candidate stage:', error);
+        throw new Error('Failed to update candidate stage');
     }
 };

--- a/backend/src/application/services/positionService.test.ts
+++ b/backend/src/application/services/positionService.test.ts
@@ -1,0 +1,73 @@
+import { PrismaClient } from '@prisma/client';
+import { getCandidatesByPositionId } from './positionService';
+
+// Mock PrismaClient
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn().mockImplementation(() => ({
+    application: {
+      findMany: jest.fn(),
+    },
+  })),
+}));
+
+describe('positionService', () => {
+  let prisma: jest.Mocked<PrismaClient>;
+
+  beforeEach(() => {
+    prisma = new PrismaClient() as jest.Mocked<PrismaClient>;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getCandidatesByPositionId', () => {
+    it('should return formatted candidate data for a given position', async () => {
+      const mockApplications = [
+        {
+          candidate: { firstName: 'John', lastName: 'Doe' },
+          currentInterviewStep: 2,
+          interviews: [{ score: 4 }, { score: 5 }],
+        },
+        {
+          candidate: { firstName: 'Jane', lastName: 'Smith' },
+          currentInterviewStep: 1,
+          interviews: [],
+        },
+      ];
+
+      (prisma.application.findMany as jest.Mock).mockResolvedValue(mockApplications);
+
+      const result = await getCandidatesByPositionId(1);
+
+      expect(prisma.application.findMany).toHaveBeenCalledWith({
+        where: { positionId: 1 },
+        include: {
+          candidate: true,
+          interviews: true,
+        },
+      });
+
+      expect(result).toEqual([
+        {
+          fullName: 'John Doe',
+          currentInterviewStep: 2,
+          averageScore: 4.5,
+        },
+        {
+          fullName: 'Jane Smith',
+          currentInterviewStep: 1,
+          averageScore: null,
+        },
+      ]);
+    });
+
+    it('should handle empty applications', async () => {
+      (prisma.application.findMany as jest.Mock).mockResolvedValue([]);
+
+      const result = await getCandidatesByPositionId(1);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/backend/src/application/services/positionService.ts
+++ b/backend/src/application/services/positionService.ts
@@ -1,0 +1,21 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export const getCandidatesByPositionId = async (positionId: number) => {
+    const applications = await prisma.application.findMany({
+        where: { positionId },
+        include: {
+            candidate: true,
+            interviews: true,
+        },
+    }) || []; // Add this fallback to an empty array
+
+    return applications.map(app => ({
+        fullName: `${app.candidate.firstName} ${app.candidate.lastName}`,
+        currentInterviewStep: app.currentInterviewStep,
+        averageScore: app.interviews.length > 0 
+            ? app.interviews.reduce((acc, interview) => acc + (interview.score || 0), 0) / app.interviews.length 
+            : null,
+    }));
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import dotenv from 'dotenv';
 import candidateRoutes from './routes/candidateRoutes';
 import { uploadFile } from './application/services/fileUploadService';
 import cors from 'cors';
+import positionRoutes from './routes/positionRoutes';
 
 // Extender la interfaz Request para incluir prisma
 declare global {
@@ -62,3 +63,6 @@ app.use((err: any, req: Request, res: Response, next: NextFunction) => {
 app.listen(port, () => {
   console.log(`Server is running at http://localhost:${port}`);
 });
+
+// Import and use positionRoutes
+app.use('/positions', positionRoutes);

--- a/backend/src/presentation/controllers/candidateController.ts
+++ b/backend/src/presentation/controllers/candidateController.ts
@@ -35,14 +35,14 @@ export const updateCandidateStageController = async (req: Request, res: Response
     try {
         const candidateId = parseInt(req.params.candidateId);
         const applicationId = parseInt(req.params.applicationId);
-        const { stage } = req.body;
+        const stage = parseInt(req.body.stage);
 
         if (isNaN(candidateId) || isNaN(applicationId)) {
             return res.status(400).json({ error: 'Invalid ID format' });
         }
 
-        if (typeof stage !== 'number' || stage < 1) {
-            return res.status(400).json({ error: 'Invalid stage format' });
+        if (isNaN(stage) || stage < 1) {
+            return res.status(400).json({ error: 'Invalid stage format: ' + (typeof stage) + ' with value: ' + stage });
         }
 
         const updatedApplication = await updateCandidateStage(candidateId, applicationId, stage);

--- a/backend/src/presentation/controllers/candidateController.ts
+++ b/backend/src/presentation/controllers/candidateController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { addCandidate, findCandidateById } from '../../application/services/candidateService';
+import { addCandidate, findCandidateById, updateCandidateStage } from '../../application/services/candidateService';
 
 export const addCandidateController = async (req: Request, res: Response) => {
     try {
@@ -27,6 +27,32 @@ export const getCandidateById = async (req: Request, res: Response) => {
         }
         res.json(candidate);
     } catch (error) {
+        res.status(500).json({ error: 'Internal Server Error' });
+    }
+};
+
+export const updateCandidateStageController = async (req: Request, res: Response) => {
+    try {
+        const candidateId = parseInt(req.params.candidateId);
+        const applicationId = parseInt(req.params.applicationId);
+        const { stage } = req.body;
+
+        if (isNaN(candidateId) || isNaN(applicationId)) {
+            return res.status(400).json({ error: 'Invalid ID format' });
+        }
+
+        if (typeof stage !== 'number' || stage < 1) {
+            return res.status(400).json({ error: 'Invalid stage format' });
+        }
+
+        const updatedApplication = await updateCandidateStage(candidateId, applicationId, stage);
+        if (!updatedApplication) {
+            return res.status(404).json({ error: 'Application not found' });
+        }
+
+        res.json(updatedApplication);
+    } catch (error) {
+        console.error('Error updating candidate stage:', error);
         res.status(500).json({ error: 'Internal Server Error' });
     }
 };

--- a/backend/src/presentation/controllers/positionController.ts
+++ b/backend/src/presentation/controllers/positionController.ts
@@ -1,0 +1,15 @@
+import { Request, Response } from 'express';
+import { getCandidatesByPositionId } from '../../application/services/positionService';
+
+export const getCandidatesByPositionIdController = async (req: Request, res: Response) => {
+    try {
+        const positionId = parseInt(req.params.id);
+        if (isNaN(positionId)) {
+            return res.status(400).json({ error: 'Invalid position ID format' });
+        }
+        const candidates = await getCandidatesByPositionId(positionId);
+        res.json(candidates);
+    } catch (error) {
+        res.status(500).json({ error: 'Internal Server Error' });
+    }
+};

--- a/backend/src/routes/candidateRoutes.ts
+++ b/backend/src/routes/candidateRoutes.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { addCandidate, getCandidateById } from '../presentation/controllers/candidateController';
+import { addCandidate, getCandidateById, updateCandidateStageController } from '../presentation/controllers/candidateController';
 
 const router = Router();
 
@@ -18,5 +18,7 @@ router.post('/', async (req, res) => {
 });
 
 router.get('/:id', getCandidateById);
+
+router.put('/:candidateId/applications/:applicationId/stage', updateCandidateStageController);
 
 export default router;

--- a/backend/src/routes/positionRoutes.ts
+++ b/backend/src/routes/positionRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getCandidatesByPositionIdController } from '../presentation/controllers/positionController';
+
+const router = Router();
+
+router.get('/:id/candidates', getCandidatesByPositionIdController);
+
+export default router;

--- a/prompts/prompts-JMLC.md
+++ b/prompts/prompts-JMLC.md
@@ -1,0 +1,823 @@
+# Comparativa con varias IA usando Cursor.sh para crear endpoint GET/positions/:id/candidates 
+
+He querido probar varios modelos para ver que resultados daban con el mismo prompt:
+
+```
+Hola. Nos han pasado el siguiente cambio para esta aplicación:
+
+"""
+GET /positions/:id/candidates
+Este endpoint recogerá todos los candidatos en proceso para una determinada posición, es decir, todas las aplicaciones para un determinado positionID. Debe proporcionar la siguiente información básica:
+
+- Nombre completo del candidato (de la tabla candidate).
+- current_interview_step: en qué fase del proceso está el candidato (de la tabla application).
+- La puntuación media del candidato. Recuerda que cada entrevist (interview) realizada por el candidato tiene un score
+"""
+
+Necesito que me ayudes a hacer los cambios en la aplicación
+Es muy importante que sigas principios de clean code, SOLID, DRY y Domain Driven Design.
+```
+
+## Claude-3.5-sonnet
+
+Para implementar el nuevo endpoint `GET /positions/:id/candidates`, seguiremos los principios de clean code, SOLID, DRY y Domain Driven Design. Aquí están los pasos necesarios:
+
+1. **Actualizar el archivo de rutas** para incluir el nuevo endpoint.
+2. **Crear un nuevo servicio** para manejar la lógica de negocio.
+3. **Actualizar el controlador** para manejar la solicitud.
+4. **Actualizar el archivo de especificaciones de la API** para documentar el nuevo endpoint.
+
+### 1. Actualizar el archivo de rutas
+
+Actualiza el archivo `backend/src/routes/candidateRoutes.ts` para incluir el nuevo endpoint:
+
+
+```20:22:backend/src/routes/candidateRoutes.ts
+router.get('/:id', getCandidateById);
+
+export default router;
+```
+
+
+```typescript:backend/src/routes/positionRoutes.ts
+import { Router } from 'express';
+import { getCandidatesByPositionId } from '../presentation/controllers/positionController';
+
+const router = Router();
+
+router.get('/:id/candidates', getCandidatesByPositionId);
+
+export default router;
+```
+
+### 2. Crear un nuevo servicio
+
+Crea un nuevo archivo `backend/src/application/services/positionService.ts` para manejar la lógica de negocio:
+
+```typescript:backend/src/application/services/positionService.ts
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export const getCandidatesByPositionId = async (positionId: number) => {
+    const applications = await prisma.application.findMany({
+        where: { positionId },
+        include: {
+            candidate: true,
+            interviews: true,
+        },
+    });
+
+    return applications.map(app => ({
+        fullName: `${app.candidate.firstName} ${app.candidate.lastName}`,
+        currentInterviewStep: app.currentInterviewStep,
+        averageScore: app.interviews.length > 0 ? app.interviews.reduce((acc, interview) => acc + (interview.score || 0), 0) / app.interviews.length : null,
+    }));
+};
+```
+
+### 3. Actualizar el controlador
+
+Actualiza el archivo `backend/src/presentation/controllers/positionController.ts` para manejar la solicitud:
+
+```typescript:backend/src/presentation/controllers/positionController.ts
+import { Request, Response } from 'express';
+import { getCandidatesByPositionId } from '../../application/services/positionService';
+
+export const getCandidatesByPositionIdController = async (req: Request, res: Response) => {
+    try {
+        const positionId = parseInt(req.params.id);
+        if (isNaN(positionId)) {
+            return res.status(400).json({ error: 'Invalid position ID format' });
+        }
+        const candidates = await getCandidatesByPositionId(positionId);
+        res.json(candidates);
+    } catch (error) {
+        res.status(500).json({ error: 'Internal Server Error' });
+    }
+};
+```
+
+### 4. Actualizar el archivo de especificaciones de la API
+
+Actualiza el archivo `backend/api-spec.yaml` para documentar el nuevo endpoint:
+
+
+```155:161:backend/api-spec.yaml
+  /upload:
+    post:
+      summary: Upload a file
+      description: Uploads a file to the server. Only PDF and DOCX files are allowed.
+      requestBody:
+        required: true
+        content:
+```
+
+
+```yaml
+  /positions/{id}/candidates:
+    get:
+      summary: Get candidates for a position
+      description: Retrieves all candidates in process for a given position.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: The ID of the position
+      responses:
+        '200':
+          description: A list of candidates
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    fullName:
+                      type: string
+                      description: Full name of the candidate
+                    currentInterviewStep:
+                      type: integer
+                      description: Current interview step of the candidate
+                    averageScore:
+                      type: number
+                      description: Average score of the candidate
+        '400':
+          description: Invalid position ID format
+        '500':
+          description: Internal server error
+```
+
+### 5. Actualizar el archivo de rutas principales
+
+Asegúrate de que el archivo `backend/src/index.ts` importe y use las nuevas rutas:
+
+
+```5:5:backend/src/index.ts
+import candidateRoutes from './routes/candidateRoutes';
+```
+
+
+```typescript:backend/src/index.ts
+import positionRoutes from './routes/positionRoutes';
+```
+
+
+```40:41:backend/src/index.ts
+app.use('/candidates', candidateRoutes);
+
+```
+
+
+```typescript:backend/src/index.ts
+app.use('/positions', positionRoutes);
+```
+
+Con estos cambios, hemos añadido un nuevo endpoint `GET /positions/:id/candidates` que sigue los principios de clean code, SOLID, DRY y Domain Driven Design.
+
+
+## o1-mini
+¡Hola! Vamos a implementar el nuevo endpoint `GET /positions/:id/candidates` siguiendo las buenas prácticas de Clean Code, SOLID, DRY y Domain-Driven Design.
+
+### 1. Actualizar el Controlador
+
+Primero, añadiremos una nueva función en el controlador de candidatos para manejar la lógica del endpoint.
+
+```typescript:backend/src/presentation/controllers/candidateController.ts
+import { Request, Response } from 'express';
+import { addCandidate, findCandidateById, getCandidatesByPositionId } from '../../application/services/candidateService';
+
+// ... otros imports y controladores existentes
+
+export const getCandidatesByPositionIdController = async (req: Request, res: Response) => {
+    try {
+        const positionId = parseInt(req.params.id);
+        if (isNaN(positionId)) {
+            return res.status(400).json({ error: 'ID de posición inválido' });
+        }
+
+        const candidates = await getCandidatesByPositionId(positionId);
+        res.json(candidates);
+    } catch (error: any) {
+        console.error('Error al obtener candidatos por posición:', error);
+        res.status(500).json({ error: 'Error interno del servidor' });
+    }
+};
+```
+
+### 2. Actualizar el Servicio
+
+Añadiremos una nueva función en el servicio de candidatos para manejar la lógica de negocio.
+
+```typescript:backend/src/application/services/candidateService.ts
+import { Candidate } from '../../domain/models/Candidate';
+import { validateCandidateData } from '../validator';
+// ... otros imports
+
+export const getCandidatesByPositionId = async (positionId: number) => {
+    try {
+        const applications = await prisma.application.findMany({
+            where: { positionId },
+            include: {
+                candidate: true,
+                interviewStep: {
+                    select: { name: true },
+                },
+                interviews: {
+                    select: { score: true },
+                },
+            },
+        });
+
+        return applications.map(app => ({
+            fullName: `${app.candidate.firstName} ${app.candidate.lastName}`,
+            currentInterviewStep: app.interviewStep.name,
+            averageScore: app.interviews.length > 0 
+                ? app.interviews.reduce((acc, curr) => acc + curr.score, 0) / app.interviews.length 
+                : null,
+        }));
+    } catch (error) {
+        console.error('Error en getCandidatesByPositionId:', error);
+        throw new Error('No se pudieron obtener los candidatos');
+    }
+};
+```
+
+### 3. Actualizar las Rutas
+
+Añadiremos una nueva ruta en `candidateRoutes.ts` para el nuevo endpoint.
+
+```typescript:backend/src/routes/candidateRoutes.ts
+import { Router } from 'express';
+import { addCandidate, getCandidateById, getCandidatesByPositionIdController } from '../presentation/controllers/candidateController';
+
+const router = Router();
+
+// Ruta existente para añadir candidato
+router.post('/', async (req, res) => {
+  try {
+    const result = await addCandidate(req.body);
+    res.status(201).send(result);
+  } catch (error: any) {
+    if (error instanceof Error) {
+      res.status(400).send({ message: error.message });
+    } else {
+      res.status(500).send({ message: "An unexpected error occurred" });
+    }
+  }
+});
+
+// Ruta existente para obtener candidato por ID
+router.get('/:id', getCandidateById);
+
+// Nueva ruta para obtener candidatos por posición
+router.get('/positions/:id/candidates', getCandidatesByPositionIdController);
+
+export default router;
+```
+
+### 4. Actualizar el Esquema de Prisma (si es necesario)
+
+Asegúrate de que las relaciones en tu esquema de Prisma estén correctamente definidas para incluir `interviewStep` e `interviews` en las consultas.
+
+```prisma
+model Application {
+  id                   Int            @id @default(autoincrement())
+  positionId           Int
+  candidateId          Int
+  applicationDate      DateTime
+  currentInterviewStep Int
+  notes                String?
+  position             Position       @relation(fields: [positionId], references: [id])
+  candidate            Candidate      @relation(fields: [candidateId], references: [id])
+  interviewStep        InterviewStep  @relation(fields: [currentInterviewStep], references: [id])
+  interviews           Interview[]
+}
+```
+
+### 5. Actualizar el Archivo de Especificación de la API
+
+Si utilizas `api-spec.yaml`, añade la nueva ruta.
+
+```yaml:backend/api-spec.yaml
+paths:
+  # ... otras rutas
+  /positions/{id}/candidates:
+    get:
+      summary: Obtener candidatos por posición
+      description: Recupera todos los candidatos en proceso para una determinada posición.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: ID de la posición
+      responses:
+        '200':
+          description: Lista de candidatos
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    fullName:
+                      type: string
+                      description: Nombre completo del candidato
+                    currentInterviewStep:
+                      type: string
+                      description: Fase actual del proceso
+                    averageScore:
+                      type: number
+                      description: Puntuación media del candidato
+        '400':
+          description: ID de posición inválido
+        '500':
+          description: Error interno del servidor
+```
+
+### 6. Buenas Prácticas Adicionales
+
+- **Validación de Entrada:** Asegúrate de validar el `positionId` en el controlador.
+- **Manejo de Errores:** Gestiona adecuadamente los posibles errores y proporciona mensajes claros.
+- **Optimización de Consultas:** Utiliza `select` en Prisma para obtener solo los campos necesarios, mejorando el rendimiento.
+
+### 7. Pruebas
+
+No olvides añadir pruebas para el nuevo endpoint para asegurar su correcto funcionamiento.
+
+```typescript:backend/src/application/tests/candidateService.test.ts
+import { getCandidatesByPositionId } from '../services/candidateService';
+import prisma from '../../prisma/client';
+
+jest.mock('../../prisma/client');
+
+describe('getCandidatesByPositionId', () => {
+    it('debería devolver una lista de candidatos con datos correctos', async () => {
+        // Configurar el mock de prisma
+        prisma.application.findMany.mockResolvedValue([
+            {
+                candidate: { firstName: 'John', lastName: 'Doe' },
+                interviewStep: { name: 'Technical Interview' },
+                interviews: [{ score: 4 }, { score: 5 }],
+            },
+            // ... otros candidatos
+        ]);
+
+        const result = await getCandidatesByPositionId(1);
+        expect(result).toEqual([
+            {
+                fullName: 'John Doe',
+                currentInterviewStep: 'Technical Interview',
+                averageScore: 4.5,
+            },
+            // ... otros candidatos
+        ]);
+    });
+
+    it('debería manejar errores correctamente', async () => {
+        prisma.application.findMany.mockRejectedValue(new Error('DB error'));
+        await expect(getCandidatesByPositionId(1)).rejects.toThrow('No se pudieron obtener los candidatos');
+    });
+});
+```
+
+### Resumen
+
+Hemos añadido:
+
+1. **Controlador:** `getCandidatesByPositionIdController` en `candidateController.ts`.
+2. **Servicio:** `getCandidatesByPositionId` en `candidateService.ts`.
+3. **Ruta:** `GET /positions/:id/candidates` en `candidateRoutes.ts`.
+4. **Esquema de API:** Definición en `api-spec.yaml`.
+5. **Pruebas:** Añadidas en `candidateService.test.ts`.
+
+Estos cambios aseguran que el nuevo endpoint se integre de manera limpia y eficiente en la aplicación existente, siguiendo las mejores prácticas de desarrollo.
+
+
+## gpt-4o
+
+Para implementar el nuevo endpoint `GET /positions/:id/candidates` siguiendo las buenas prácticas de Clean Code, SOLID, DRY y Domain-Driven Design, sigue estos pasos:
+
+### 1. Actualizar el archivo de rutas
+
+Actualiza el archivo `backend/src/routes/positionRoutes.ts` para incluir el nuevo endpoint:
+
+```typescript:backend/src/routes/positionRoutes.ts
+import { Router } from 'express';
+import { getCandidatesByPositionIdController } from '../presentation/controllers/positionController';
+
+const router = Router();
+
+router.get('/:id/candidates', getCandidatesByPositionIdController);
+
+export default router;
+```
+
+### 2. Crear un nuevo servicio
+
+Crea un nuevo archivo `backend/src/application/services/positionService.ts` para manejar la lógica de negocio:
+
+```typescript:backend/src/application/services/positionService.ts
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export const getCandidatesByPositionId = async (positionId: number) => {
+    const applications = await prisma.application.findMany({
+        where: { positionId },
+        include: {
+            candidate: true,
+            interviews: true,
+        },
+    });
+
+    return applications.map(app => ({
+        fullName: `${app.candidate.firstName} ${app.candidate.lastName}`,
+        currentInterviewStep: app.currentInterviewStep,
+        averageScore: app.interviews.length > 0 
+            ? app.interviews.reduce((acc, interview) => acc + (interview.score || 0), 0) / app.interviews.length 
+            : null,
+    }));
+};
+```
+
+### 3. Actualizar el controlador
+
+Actualiza el archivo `backend/src/presentation/controllers/positionController.ts` para manejar la solicitud:
+
+```typescript:backend/src/presentation/controllers/positionController.ts
+import { Request, Response } from 'express';
+import { getCandidatesByPositionId } from '../../application/services/positionService';
+
+export const getCandidatesByPositionIdController = async (req: Request, res: Response) => {
+    try {
+        const positionId = parseInt(req.params.id);
+        if (isNaN(positionId)) {
+            return res.status(400).json({ error: 'Invalid position ID format' });
+        }
+        const candidates = await getCandidatesByPositionId(positionId);
+        res.json(candidates);
+    } catch (error) {
+        res.status(500).json({ error: 'Internal Server Error' });
+    }
+};
+```
+
+### 4. Actualizar el archivo de especificaciones de la API
+
+Actualiza el archivo `backend/api-spec.yaml` para documentar el nuevo endpoint:
+
+```yaml:backend/api-spec.yaml
+paths:
+  /positions/{id}/candidates:
+    get:
+      summary: Get candidates for a position
+      description: Retrieves all candidates in process for a given position.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: The ID of the position
+      responses:
+        '200':
+          description: A list of candidates
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    fullName:
+                      type: string
+                      description: Full name of the candidate
+                    currentInterviewStep:
+                      type: integer
+                      description: Current interview step of the candidate
+                    averageScore:
+                      type: number
+                      description: Average score of the candidate
+        '400':
+          description: Invalid position ID format
+        '500':
+          description: Internal server error
+```
+
+### 5. Actualizar el archivo de rutas principales
+
+Asegúrate de que el archivo `backend/src/index.ts` importe y use las nuevas rutas:
+
+```typescript:backend/src/index.ts
+import positionRoutes from './routes/positionRoutes';
+
+app.use('/positions', positionRoutes);
+```
+
+Con estos cambios, hemos añadido un nuevo endpoint `GET /positions/:id/candidates` que sigue los principios de Clean Code, SOLID, DRY y Domain-Driven Design.
+
+
+## Comparativa
+
+|                           | Claude 3.5   |   o1-mini  |   gpt-4o | o1-mini (de nuevo)
+| Ruta separada /positions  |      SI      |     NO     |     SI   |   SI
+| Controlador separado      |      SI      |     NO     |     SI   |   SI
+| Servicio separado         |      SI      |     NO     |     SI   |   SI
+| Completar api-spec.yml    |      SI+     |     SI-    |     SI+  |   SI+
+| Test                      |      NO      |     SI-    |     NO   |   NO
+
+- Calidad del código muy similar, tratan error de parámetro para devolver un 400, hacen try-catch para devolver 500, ...
+    - Todos colocan el uso de positionRoutes en index.ts, lo coloca al final
+    - Claude declaraba el método `positionController.getCandidatesByPositionIdController` pero luego lo usaba con otro nombre `getCandidatesByPositionId`
+- El api-spec.yml o1-mini ha completado en castellano mientras que Claude y 4o ha hecho en inglés como el resto de fichero.
+- KO: o1-mini Dice de actualizar el esquema de Prisma si es necesario...es confuso si no es necesario
+
+# Prompt 2: Crear un test unitario para el servicio creado
+
+Puedes crear un test unitario para @positionService.ts ?
+Recuerda que debes mockear dependencias externas como Prisma.
+
+## o1-mini
+
+### Respuesta
+
+```
+import { getCandidatesByPositionId } from './positionService';
+import { PrismaClient, Application } from '@prisma/client';
+
+jest.mock('@prisma/client', () => {
+    const mPrismaClient = {
+        application: {
+            findMany: jest.fn(),
+        },
+    };
+    return { PrismaClient: jest.fn(() => mPrismaClient) };
+});
+
+const mockPrisma = new PrismaClient();
+
+describe('getCandidatesByPositionId', () => {
+    beforeAll(() => {
+        (PrismaClient as jest.Mock).mockImplementation(() => mockPrisma);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should return a list of candidates with correct data', async () => {
+        const positionId = 1;
+        const mockApplications: Application[] = [
+            {
+                id: 1,
+                positionId: positionId,
+                candidateId: 1,
+                applicationDate: new Date(),
+                currentInterviewStep: 2,
+                notes: 'Application notes',
+                candidate: {
+                    id: 1,
+                    firstName: 'John',
+                    lastName: 'Doe',
+                    email: 'john.doe@example.com',
+                    phone: '1234567890',
+                    address: '123 Main St',
+                    educations: [],
+                    workExperiences: [],
+                    resumes: [],
+                    applications: [],
+                },
+                interviews: [
+                    { id: 1, applicationId: 1, interviewStepId: 2, employeeId: 1, interviewDate: new Date(), result: 'Passed', score: 4, notes: 'Good performance' },
+                    { id: 2, applicationId: 1, interviewStepId: 2, employeeId: 2, interviewDate: new Date(), result: 'Passed', score: 5, notes: 'Excellent performance' },
+                ],
+            },
+        ];
+
+        mockPrisma.application.findMany.mockResolvedValue(mockApplications);
+
+        const result = await getCandidatesByPositionId(positionId);
+
+        expect(mockPrisma.application.findMany).toHaveBeenCalledWith({
+            where: { positionId },
+            include: {
+                candidate: true,
+                interviews: true,
+            },
+        });
+
+        expect(result).toEqual([
+            {
+                fullName: 'John Doe',
+                currentInterviewStep: 2,
+                averageScore: 4.5,
+            },
+        ]);
+    });
+
+    it('should return an empty list if there are no applications', async () => {
+        const positionId = 2;
+
+        mockPrisma.application.findMany.mockResolvedValue([]);
+
+        const result = await getCandidatesByPositionId(positionId);
+
+        expect(mockPrisma.application.findMany).toHaveBeenCalledWith({
+            where: { positionId },
+            include: {
+                candidate: true,
+                interviews: true,
+            },
+        });
+
+        expect(result).toEqual([]);
+    });
+
+    it('should handle errors correctly', async () => {
+        const positionId = 3;
+        const errorMessage = 'Database error';
+
+        mockPrisma.application.findMany.mockRejectedValue(new Error(errorMessage));
+
+        await expect(getCandidatesByPositionId(positionId)).rejects.toThrow(errorMessage);
+
+        expect(mockPrisma.application.findMany).toHaveBeenCalledWith({
+            where: { positionId },
+            include: {
+                candidate: true,
+                interviews: true,
+            },
+        });
+    });
+});
+```
+
+### Prompt para corregir error
+
+```
+Al ejecutar con `npm test` se produce el siguiente error:
+
+ FAIL  dist/application/services/positionService.test.js
+  ● getCandidatesByPositionId › debería devolver una lista de candidatos con datos correctos
+
+    TypeError: prisma.application.findMany.mockResolvedValue is not a function
+```
+
+**Da el mismo error**
+
+
+## Claude 3.5
+
+### Respuesta
+
+```
+import { PrismaClient } from '@prisma/client';
+import { getCandidatesByPositionId } from './positionService';
+
+// Mock PrismaClient
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn().mockImplementation(() => ({
+    application: {
+      findMany: jest.fn(),
+    },
+  })),
+}));
+
+describe('positionService', () => {
+  let prisma: jest.Mocked<PrismaClient>;
+
+  beforeEach(() => {
+    prisma = new PrismaClient() as jest.Mocked<PrismaClient>;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getCandidatesByPositionId', () => {
+    it('should return formatted candidate data for a given position', async () => {
+      const mockApplications = [
+        {
+          candidate: { firstName: 'John', lastName: 'Doe' },
+          currentInterviewStep: 2,
+          interviews: [{ score: 4 }, { score: 5 }],
+        },
+        {
+          candidate: { firstName: 'Jane', lastName: 'Smith' },
+          currentInterviewStep: 1,
+          interviews: [],
+        },
+      ];
+
+      (prisma.application.findMany as jest.Mock).mockResolvedValue(mockApplications);
+
+      const result = await getCandidatesByPositionId(1);
+
+      expect(prisma.application.findMany).toHaveBeenCalledWith({
+        where: { positionId: 1 },
+        include: {
+          candidate: true,
+          interviews: true,
+        },
+      });
+
+      expect(result).toEqual([
+        {
+          fullName: 'John Doe',
+          currentInterviewStep: 2,
+          averageScore: 4.5,
+        },
+        {
+          fullName: 'Jane Smith',
+          currentInterviewStep: 1,
+          averageScore: null,
+        },
+      ]);
+    });
+
+    it('should handle empty applications', async () => {
+      (prisma.application.findMany as jest.Mock).mockResolvedValue([]);
+
+      const result = await getCandidatesByPositionId(1);
+
+      expect(result).toEqual([]);
+    });
+  });
+});
+```
+
+### Error
+
+**Da el mismo error y con Debug with AI tampoco se corrige**
+
+
+# Poblar de datos con seed.ts
+
+No podía ejecutar `ts-node seed.ts` como dice el Readme.md. He pedido ayuda al chat y me ha dicho lo siguiente, que no ha funcionado:
+
+## Respuesta
+
+Entiendo que estás teniendo problemas para ejecutar `ts-node`. Vamos a resolver esto paso a paso:
+
+1. Primero, asegúrate de que `ts-node` está instalado. Si no lo has instalado aún, puedes hacerlo con:
+
+   ```
+   npm install -g ts-node typescript
+   ```
+
+   O si prefieres instalarlo localmente en tu proyecto:
+
+   ```
+   npm install --save-dev ts-node typescript
+   ```
+
+2. Si lo has instalado localmente, deberías usar `npx` para ejecutarlo:
+
+   ```
+   npx ts-node seed.ts
+   ```
+
+3. Si aún así no funciona, podemos agregar un script en tu `package.json`:
+
+   ```json:backend/package.json
+   "scripts": {
+     // ... otros scripts
+     "seed": "ts-node prisma/seed.ts"
+   },
+   ```
+
+   Luego podrías ejecutar:
+
+   ```
+   npm run seed
+   ```
+
+4. Si sigues teniendo problemas, asegúrate de que estás en el directorio correcto. Deberías estar en la raíz de tu proyecto backend, no dentro de la carpeta `prisma`.
+
+5. Verifica que Node.js está instalado correctamente:
+
+   ```
+   node --version
+   ```
+
+6. Si todo lo anterior falla, puedes intentar usar `node` directamente con `ts-node/register`:
+
+   ```
+   node -r ts-node/register prisma/seed.ts
+   ```
+
+7. Finalmente, si nada de esto funciona, podrías compilar el archivo TypeScript a JavaScript y luego ejecutarlo con Node:
+
+   ```
+   tsc prisma/seed.ts
+   node prisma/seed.js
+   ```
+
+Si aún tienes problemas después de intentar estas soluciones, por favor proporciona más detalles sobre tu entorno de desarrollo (versión de Node.js, contenido de tu `package.json`, estructura de directorios, etc.) para que pueda ayudarte mejor.

--- a/prompts/prompts-JMLC.md
+++ b/prompts/prompts-JMLC.md
@@ -1210,7 +1210,123 @@ Esta implementación sigue los principios SOLID, DRY y Domain-Driven Design:
 5. Domain-Driven Design: La lógica de negocio está encapsulada en el servicio, separada de la capa de presentación.
 
 
-# Prompt para Fix petición PUT
+# Pruebas de los endpoints
+
+## GET
+```
+<▸> ~ http :3010/positions/1/candidates
+HTTP/1.1 200 OK
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Origin: http://localhost:3000
+Connection: keep-alive
+Content-Length: 210
+Content-Type: application/json; charset=utf-8
+Date: Wed, 18 Sep 2024 06:58:12 GMT
+ETag: W/"d2-G9287OrorG+QP+lvHK4zEudxVGg"
+Keep-Alive: timeout=5
+Vary: Origin
+X-Powered-By: Express
+
+[
+    {
+        "averageScore": 5,
+        "currentInterviewStep": 2,
+        "fullName": "John Doe"
+    },
+    {
+        "averageScore": 4,
+        "currentInterviewStep": 2,
+        "fullName": "Jane Smith"
+    },
+    {
+        "averageScore": null,
+        "currentInterviewStep": 1,
+        "fullName": "Carlos García"
+    }
+]
+
+```
+
+## PUT (ERROR)
+
+```
+<▸> ~ http PUT :3010/candidates/3/applications/4/stage stage=2
+HTTP/1.1 400 Bad Request
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Origin: http://localhost:3000
+Connection: keep-alive
+Content-Length: 32
+Content-Type: application/json; charset=utf-8
+Date: Wed, 18 Sep 2024 06:45:47 GMT
+ETag: W/"20-XLmEO/wOPkbView69Ek7iVULuSc"
+Keep-Alive: timeout=5
+Vary: Origin
+X-Powered-By: Express
+
+{
+    "error": "Invalid stage format"
+}
+```
+
+
+### Prompt para Fix petición PUT
 ```
 el campo 'stage' llega como "string". Como puedo validarlo como número?
+```
+
+
+## PUT (Fixed)
+
+```
+http PUT :3010/candidates/3/applications/4/stage stage=2
+
+
+HTTP/1.1 200 OK
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Origin: http://localhost:3000
+Connection: keep-alive
+Content-Length: 923
+Content-Type: application/json; charset=utf-8
+Date: Wed, 18 Sep 2024 06:52:37 GMT
+ETag: W/"39b-T2h/J+vfRyZ1RsXfDQjQcSk/m7Q"
+Keep-Alive: timeout=5
+Vary: Origin
+X-Powered-By: Express
+
+{
+    "applicationDate": "2024-09-18T06:14:49.182Z",
+    "candidate": {
+        "address": "789 Pine St",
+        "email": "carlos.garcia@example.com",
+        "firstName": "Carlos",
+        "id": 3,
+        "lastName": "García",
+        "phone": "1122334455"
+    },
+    "candidateId": 3,
+    "currentInterviewStep": 2,
+    "id": 4,
+    "notes": null,
+    "position": {
+        "applicationDeadline": "2024-12-31T00:00:00.000Z",
+        "benefits": "Health insurance, 401k, Paid time off",
+        "companyDescription": "LTI is a leading HR solutions provider.",
+        "companyId": 1,
+        "contactInfo": "hr@lti.com",
+        "description": "Develop and maintain software applications.",
+        "employmentType": "Full-time",
+        "id": 1,
+        "interviewFlowId": 1,
+        "isVisible": true,
+        "jobDescription": "Full-stack development",
+        "location": "Remote",
+        "requirements": "3+ years of experience in software development, knowledge in React and Node.js",
+        "responsibilities": "Develop, test, and maintain software solutions.",
+        "salaryMax": 80000,
+        "salaryMin": 50000,
+        "status": "Open",
+        "title": "Software Engineer"
+    },
+    "positionId": 1
+}
 ```


### PR DESCRIPTION
WiP: Falta el segundo endpoint

En prompts.md he añadido los prompts aunque el primero he probado con distintos modelos (gpt-4o, o1-mini y claude-3.5) con una pequeña comparativa al final. 
Bastante similares aunque la primera vez que he usado o1-mini no me ha dado una buena respuesta, a pesar de darle todo el contexto como en los demás modelos. Después lo he reintentado en un chat nuevo (como en todos) y ya ha dado mejor resultado.

Los test, una vez más, muchos problemas con el mock de prisma... incapaz ninguno de hacerlo funcionar ni a la primera ni pidiendo corregir los errores una y otra vez, no sé si problema de la versión o que...

Tampoco he sido capaz de poblar la BBDD con el comando que indica el Readme `ts-node seed.ts` y la IA tampoco me ha ayudado demasiado...